### PR TITLE
Show satellite photo thumbnails in toolbar

### DIFF
--- a/SkyRoof/Context.cs
+++ b/SkyRoof/Context.cs
@@ -24,6 +24,7 @@ namespace SkyRoof
     public SatelliteSelectorWidget SatelliteSelector;
     public FrequencyWidget FrequencyControl;
     public RotatorWidget RotatorControl;
+    public SatellitePhotoWidget SatellitePhotoWidget;
 
     // panels
     public GroupViewPanel? GroupViewPanel;

--- a/SkyRoof/Forms/MainForm.Designer.cs
+++ b/SkyRoof/Forms/MainForm.Designer.cs
@@ -140,6 +140,7 @@
       RotatorWidget.Size = new Size(210, 78);
       RotatorWidget.TabIndex = 8;
       // 
+      // 
       // panel7
       // 
       panel7.Dock = DockStyle.Left;
@@ -834,6 +835,7 @@
     private ToolStripStatusLabel RxCatLedLabel;
     private ToolStripStatusLabel RxCatStatusLabel;
     private RotatorWidget RotatorWidget;
+    public SatellitePhotoWidget SatellitePhotoWidget;
     private Panel panel5;
     private Panel panel4;
     private ToolStripStatusLabel RotatorLedLabel;

--- a/SkyRoof/Forms/MainForm.Designer.cs
+++ b/SkyRoof/Forms/MainForm.Designer.cs
@@ -32,6 +32,7 @@
       System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainForm));
       Toolbar = new Panel();
       RotatorWidget = new RotatorWidget();
+      SatellitePhotoWidget = new SatellitePhotoWidget();
       panel7 = new Panel();
       GainWidget = new GainWidget();
       panel3 = new Panel();
@@ -121,6 +122,7 @@
       Toolbar.Controls.Add(panel3);
       Toolbar.Controls.Add(FrequencyWidget);
       Toolbar.Controls.Add(panel1);
+      Toolbar.Controls.Add(SatellitePhotoWidget);
       Toolbar.Controls.Add(SatelliteSelecionWidget);
       Toolbar.Controls.Add(ClockPanel);
       Toolbar.Controls.Add(panel2);
@@ -140,6 +142,14 @@
       RotatorWidget.Size = new Size(210, 78);
       RotatorWidget.TabIndex = 8;
       // 
+      // SatellitePhotoWidget
+      // 
+      SatellitePhotoWidget.BorderStyle = BorderStyle.FixedSingle;
+      SatellitePhotoWidget.Dock = DockStyle.Left;
+      SatellitePhotoWidget.Location = new Point(4, 0);
+      SatellitePhotoWidget.Name = "SatellitePhotoWidget";
+      SatellitePhotoWidget.Size = new Size(90, 78);
+      SatellitePhotoWidget.TabIndex = 11;
       // 
       // panel7
       // 

--- a/SkyRoof/Forms/MainForm.cs
+++ b/SkyRoof/Forms/MainForm.cs
@@ -27,12 +27,14 @@ namespace SkyRoof
       ctx.SatelliteSelector = SatelliteSelecionWidget;
       ctx.FrequencyControl = FrequencyWidget;
       ctx.RotatorControl = RotatorWidget;
+      ctx.SatellitePhotoWidget = SatellitePhotoWidget;
       SatelliteSelecionWidget.ctx = ctx;
       FrequencyWidget.ctx = ctx;
       GainWidget.ctx = ctx;
       ctx.Announcer.ctx = ctx;
       ctx.CatControl.ctx = ctx;
       ctx.RotatorControl.ctx = ctx;
+      SatellitePhotoWidget.ctx = ctx;
       ctx.AmsatStatusLoader.ctx = ctx;
       ctx.UdpStreamSender.ctx = ctx;
 
@@ -55,6 +57,9 @@ namespace SkyRoof
       ApplyOutputStreamSettings();
       ctx.CatControl.ApplySettings();
       ctx.RotatorControl.ApplySettings();
+
+      Resize += (s, e) => UpdateSatellitePhotoVisibility();
+      UpdateSatellitePhotoVisibility();
     }
 
     private void MainForm_Load(object sender, EventArgs e)
@@ -972,6 +977,7 @@ namespace SkyRoof
       ctx.PassesPanel?.ShowPasses();
       ctx.SkyViewPanel?.ClearPass();
       ctx.WaterfallPanel?.ScaleControl?.BuildLabels();
+      SatellitePhotoWidget.SetSatellite(ctx.SatelliteSelector.SelectedSatellite);
 
       ShowSatDataStatus();
     }
@@ -1028,6 +1034,7 @@ namespace SkyRoof
       ctx.TransmittersPanel?.SetSatellite();
       ctx.PassesPanel?.ShowPasses();
       ctx.QsoEntryPanel?.SetSatellite();
+      SatellitePhotoWidget.SetSatellite(ctx.SatelliteSelector.SelectedSatellite);
     }
 
     private void SatelliteSelector_SelectedTransmitterChanged(object sender, EventArgs e)
@@ -1057,6 +1064,27 @@ namespace SkyRoof
     private void RotatorTrackMNU_CheckedChanged(object sender, EventArgs e)
     {
       RotatorWidget.ToggleTracking();
+    }
+
+    private void UpdateSatellitePhotoVisibility()
+    {
+      if (SatellitePhotoWidget == null) return;
+
+      // Show only when toolbar is wide enough to fit everything (keep existing widgets visible first).
+      int required =
+        panel2.Width +
+        SatellitePhotoWidget.Width +
+        SatelliteSelecionWidget.Width +
+        panel1.Width +
+        FrequencyWidget.Width +
+        panel3.Width +
+        GainWidget.Width +
+        panel7.Width +
+        RotatorWidget.Width +
+        panel5.Width +
+        ClockPanel.Width;
+
+      SatellitePhotoWidget.Visible = Toolbar.ClientSize.Width >= required + 10;
     }
   }
 }

--- a/SkyRoof/Widgets/SatellitePhotoWidget.cs
+++ b/SkyRoof/Widgets/SatellitePhotoWidget.cs
@@ -1,0 +1,154 @@
+using System.Net.Http;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using VE3NEA;
+
+namespace SkyRoof
+{
+  public class SatellitePhotoWidget : UserControl
+  {
+    public Context ctx;
+
+    private readonly PictureBox picture = new();
+    private readonly ToolTip toolTip = new();
+
+    private static readonly HttpClient Http = new HttpClient();
+    private CancellationTokenSource? Cts;
+    private string? CurrentSatId;
+
+    public static readonly Size CacheImageSize = new(160, 160);
+    private const int CacheVersion = 2;
+
+    public SatellitePhotoWidget()
+    {
+      BorderStyle = BorderStyle.FixedSingle;
+      BuildUi();
+    }
+
+    private void BuildUi()
+    {
+      picture.Dock = DockStyle.Fill;
+      picture.SizeMode = PictureBoxSizeMode.Zoom;
+      // Let the toolbar background show through cached PNG alpha.
+      picture.BackColor = Color.Transparent;
+      Controls.Add(picture);
+    }
+
+    public void SetSatellite(SatnogsDbSatellite? sat)
+    {
+      if (sat == null)
+      {
+        CurrentSatId = null;
+        SetImage(null);
+        return;
+      }
+
+      if (sat.sat_id == CurrentSatId) return;
+      CurrentSatId = sat.sat_id;
+
+      toolTip.SetToolTip(picture, sat.name);
+
+      if (string.IsNullOrEmpty(sat.image))
+      {
+        SetImage(null);
+        return;
+      }
+
+      var url = $"https://db-satnogs.freetls.fastly.net/media/{sat.image}";
+      LoadOrDownloadAsync(sat, url).DoNotAwait();
+    }
+
+    private async Task LoadOrDownloadAsync(SatnogsDbSatellite sat, string url)
+    {
+      Cts?.Cancel();
+      Cts = new CancellationTokenSource();
+      var ct = Cts.Token;
+
+      try
+      {
+        string cacheFile = GetCacheFilePath(sat.sat_id);
+        if (File.Exists(cacheFile))
+        {
+          SetImage(LoadBitmapNoLock(cacheFile));
+          return;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(cacheFile)!);
+
+        byte[] bytes = await Http.GetByteArrayAsync(url, ct);
+        ct.ThrowIfCancellationRequested();
+
+        using var ms = new MemoryStream(bytes);
+        using var original = Image.FromStream(ms);
+        using var resized = ResizeToFit(original, CacheImageSize);
+
+        resized.Save(cacheFile, ImageFormat.Png);
+        ct.ThrowIfCancellationRequested();
+
+        SetImage(new Bitmap(resized));
+      }
+      catch (OperationCanceledException)
+      {
+        // ignore
+      }
+      catch
+      {
+        // download or decode failure; just show blank
+        SetImage(null);
+      }
+    }
+
+    private static string GetCacheFilePath(string satId)
+    {
+      string dir = Path.Combine(Utils.GetUserDataFolder(), "sat_images");
+      string baseName = Utils.SanitizeFileNamePart(satId);
+      string file = $"{baseName}_v{CacheVersion}_{CacheImageSize.Width}x{CacheImageSize.Height}.png";
+      return Path.Combine(dir, file);
+    }
+
+    private static Bitmap LoadBitmapNoLock(string path)
+    {
+      using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+      using var img = Image.FromStream(fs);
+      return new Bitmap(img);
+    }
+
+    private static Bitmap ResizeToFit(Image src, Size target)
+    {
+      var dest = new Bitmap(target.Width, target.Height, PixelFormat.Format32bppPArgb);
+      dest.SetResolution(96, 96);
+
+      using var g = Graphics.FromImage(dest);
+      g.Clear(Color.Transparent);
+      g.CompositingQuality = CompositingQuality.HighQuality;
+      g.InterpolationMode = InterpolationMode.HighQualityBicubic;
+      g.PixelOffsetMode = PixelOffsetMode.HighQuality;
+      g.SmoothingMode = SmoothingMode.HighQuality;
+
+      float scale = Math.Min((float)target.Width / src.Width, (float)target.Height / src.Height);
+      int w = Math.Max(1, (int)Math.Round(src.Width * scale));
+      int h = Math.Max(1, (int)Math.Round(src.Height * scale));
+      int x = (target.Width - w) / 2;
+      int y = (target.Height - h) / 2;
+
+      g.DrawImage(src, new Rectangle(x, y, w, h));
+      return dest;
+    }
+
+    private void SetImage(Image? img)
+    {
+      if (IsDisposed) { img?.Dispose(); return; }
+
+      if (InvokeRequired)
+      {
+        BeginInvoke(() => SetImage(img));
+        return;
+      }
+
+      var old = picture.Image;
+      picture.Image = img;
+      old?.Dispose();
+    }
+  }
+}
+


### PR DESCRIPTION
This change adds the satellite photo thumbnails in the toolbar for the currently selected satellite. The image is auto-hidden if the window is not wide enough. Images are resized and saved locally.

<img width="624" height="428" alt="image" src="https://github.com/user-attachments/assets/659db373-e718-4801-85d9-682773e3cd56" />
