### PR TITLE
fix 500ms lag when changing frequencies

### DIFF
--- a/SkyRoof/CAT/CatControl.cs
+++ b/SkyRoof/CAT/CatControl.cs
@@ -1,73 +1,168 @@
-﻿namespace SkyRoof
-{
-  public class CatControl
-  {
-    public Context ctx;
-    public CatControlEngine? Rx, Tx;
-
-
-    internal void ApplySettings()
-    {
-      bool crossband = ctx.FrequencyControl.RadioLink.IsCrossBand;
-
-      Rx?.Dispose();
-      Tx?.Dispose();
-
-      // create rx cat engine
-      if (!ctx.Settings.Cat.RxCat.Enabled)
-        Rx = null;
-      else 
-        Rx = new CatControlEngine(ctx.Settings.Cat.RxCat, ctx.Settings.Cat);
-
-      // create tx cat engine
-      if (!ctx.Settings.Cat.TxCat.Enabled || !ctx.FrequencyControl.RadioLink.HasUplink)
-        Tx = null;
-      else if (IsSameEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat.RxCat))
-        Tx = Rx;      
-      else
-        Tx = new CatControlEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat);
-
-      // start engines
-      if (Rx != null)
-      {
-        Rx.RxTuned += (s, e) => ctx.FrequencyControl.RxTuned();
-        Rx.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
-        Rx.Start(true, Tx == Rx, crossband);
-      }
-      if (Tx != null)
-      {
-        Tx.TxTuned += (s, e) => ctx.FrequencyControl.TxTuned();
-        if (Tx != Rx)
-        {
-          Tx.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
-          Tx.Start(false, true, crossband);
-        }
-      }
-
-      ctx.MainForm.ShowCatStatus();
-    }
-
-    private static bool IsSameEngine(CatRadioSettings txCat, CatRadioSettings rxCat)
-    {
-      return rxCat.Enabled
-        && txCat.Enabled
-        && IsSameHostPort(rxCat, txCat);
-        //&& rxCat.RadioType == txCat.RadioType;
-    }
-
-    public static bool IsSameHostPort(CatRadioSettings txCat, CatRadioSettings rxCat)
-    {
-      if (rxCat.Port != txCat.Port) return false;
-      if (string.IsNullOrEmpty(rxCat.Host) || string.IsNullOrEmpty(txCat.Host))
-        return false;
-
-      string host1 = rxCat.Host;
-      string host2 = txCat.Host;
-
-      if (host1 == "127.0.0.1") host1 = "localhost";
-      if (host2 == "127.0.0.1") host2 = "localhost";
-
-      return string.Equals(host1, host2, StringComparison.OrdinalIgnoreCase);
-    }
-  }
-}
+﻿namespace SkyRoof
+{
+  public class CatControl
+  {
+    public Context ctx;
+    public CatControlEngine? Rx, Tx;
+    private bool rxEngineIncludesTx;
+
+    /// <summary>
+    /// Ensures CAT engines match settings and link topology. Does not restart engines
+    /// when only frequency/mode changed — <see cref="FrequencyWidget"/> pushes those via
+    /// SetRxFrequency / SetRxMode / SetTxFrequency on the live engines.
+    /// </summary>
+    internal void ApplyTune()
+    {
+      var link = ctx.FrequencyControl.RadioLink;
+      bool crossband = link.IsCrossBand;
+      bool wantRx = ctx.Settings.Cat.RxCat.Enabled;
+      bool wantTx = ctx.Settings.Cat.TxCat.Enabled && link.HasUplink;
+      bool wantShare = wantTx && wantRx && IsSameEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat.RxCat);
+      bool rxAlsoTx = wantTx && wantShare;
+
+      SyncRxEngine(wantRx, rxAlsoTx, crossband);
+      SyncTxEngine(wantTx, wantShare, crossband);
+
+      ctx.MainForm.ShowCatStatus();
+    }
+
+    internal void ApplySettings()
+    {
+      DestroyAllEngines();
+      ApplyTune();
+    }
+
+    private void SyncRxEngine(bool wantRx, bool rxAlsoTx, bool crossband)
+    {
+      if (!wantRx)
+      {
+        if (Rx != null) RemoveRxEngine();
+        return;
+      }
+
+      if (Rx == null)
+      {
+        Rx = CreateRxEngine();
+        Rx.Start(true, rxAlsoTx, crossband);
+        rxEngineIncludesTx = rxAlsoTx;
+        if (rxAlsoTx) Tx = Rx;
+        return;
+      }
+
+      if (rxEngineIncludesTx != rxAlsoTx)
+        ReconfigureRxEngine(rxAlsoTx, crossband);
+    }
+
+    private void SyncTxEngine(bool wantTx, bool wantShare, bool crossband)
+    {
+      if (!wantTx)
+      {
+        if (Tx != null) RemoveTxEngine();
+        return;
+      }
+
+      if (wantShare)
+      {
+        if (Rx == null)
+        {
+          if (Tx != null) RemoveTxEngine();
+          return;
+        }
+
+        if (Tx != null && Tx != Rx)
+          RemoveTxEngine();
+
+        Tx = Rx;
+        return;
+      }
+
+      if (Tx == Rx)
+        Tx = null;
+
+      if (Tx != null) return;
+
+      Tx = CreateTxEngine();
+      Tx.Start(false, true, crossband);
+    }
+
+    private void ReconfigureRxEngine(bool rxAlsoTx, bool crossband)
+    {
+      RemoveRxEngine();
+      Rx = CreateRxEngine();
+      Rx.Start(true, rxAlsoTx, crossband);
+      rxEngineIncludesTx = rxAlsoTx;
+      if (rxAlsoTx) Tx = Rx;
+    }
+
+    private void RemoveRxEngine()
+    {
+      if (Rx == null) return;
+      if (Tx == Rx) Tx = null;
+      Rx.Dispose();
+      Rx = null;
+      rxEngineIncludesTx = false;
+    }
+
+    private void RemoveTxEngine()
+    {
+      if (Tx == null) return;
+      if (Tx != Rx)
+      {
+        Tx.Dispose();
+        Tx = null;
+      }
+      else
+        Tx = null;
+    }
+
+    private void DestroyAllEngines()
+    {
+      if (Tx != null && Tx != Rx) Tx.Dispose();
+      if (Tx == Rx) Tx = null;
+      Rx?.Dispose();
+      Rx = null;
+      Tx = null;
+      rxEngineIncludesTx = false;
+    }
+
+    private CatControlEngine CreateRxEngine()
+    {
+      var engine = new CatControlEngine(ctx.Settings.Cat.RxCat, ctx.Settings.Cat);
+      engine.RxTuned += (s, e) => ctx.FrequencyControl.RxTuned();
+      engine.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
+      return engine;
+    }
+
+    private CatControlEngine CreateTxEngine()
+    {
+      var engine = new CatControlEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat);
+      engine.TxTuned += (s, e) => ctx.FrequencyControl.TxTuned();
+      engine.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
+      return engine;
+    }
+
+    private static bool IsSameEngine(CatRadioSettings txCat, CatRadioSettings rxCat)
+    {
+      return rxCat.Enabled
+        && txCat.Enabled
+        && IsSameHostPort(rxCat, txCat);
+        //&& rxCat.RadioType == txCat.RadioType;
+    }
+
+    public static bool IsSameHostPort(CatRadioSettings txCat, CatRadioSettings rxCat)
+    {
+      if (rxCat.Port != txCat.Port) return false;
+      if (string.IsNullOrEmpty(rxCat.Host) || string.IsNullOrEmpty(txCat.Host))
+        return false;
+
+      string host1 = rxCat.Host;
+      string host2 = txCat.Host;
+
+      if (host1 == "127.0.0.1") host1 = "localhost";
+      if (host2 == "127.0.0.1") host2 = "localhost";
+
+      return string.Equals(host1, host2, StringComparison.OrdinalIgnoreCase);
+    }
+  }
+}
+

--- a/SkyRoof/CAT/CatControl.cs
+++ b/SkyRoof/CAT/CatControl.cs
@@ -1,168 +1,181 @@
-﻿namespace SkyRoof
-{
-  public class CatControl
-  {
-    public Context ctx;
-    public CatControlEngine? Rx, Tx;
-    private bool rxEngineIncludesTx;
-
-    /// <summary>
-    /// Ensures CAT engines match settings and link topology. Does not restart engines
-    /// when only frequency/mode changed — <see cref="FrequencyWidget"/> pushes those via
-    /// SetRxFrequency / SetRxMode / SetTxFrequency on the live engines.
-    /// </summary>
-    internal void ApplyTune()
-    {
-      var link = ctx.FrequencyControl.RadioLink;
-      bool crossband = link.IsCrossBand;
-      bool wantRx = ctx.Settings.Cat.RxCat.Enabled;
-      bool wantTx = ctx.Settings.Cat.TxCat.Enabled && link.HasUplink;
-      bool wantShare = wantTx && wantRx && IsSameEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat.RxCat);
-      bool rxAlsoTx = wantTx && wantShare;
-
-      SyncRxEngine(wantRx, rxAlsoTx, crossband);
-      SyncTxEngine(wantTx, wantShare, crossband);
-
-      ctx.MainForm.ShowCatStatus();
-    }
-
-    internal void ApplySettings()
-    {
-      DestroyAllEngines();
-      ApplyTune();
-    }
-
-    private void SyncRxEngine(bool wantRx, bool rxAlsoTx, bool crossband)
-    {
-      if (!wantRx)
-      {
-        if (Rx != null) RemoveRxEngine();
-        return;
-      }
-
-      if (Rx == null)
-      {
-        Rx = CreateRxEngine();
-        Rx.Start(true, rxAlsoTx, crossband);
-        rxEngineIncludesTx = rxAlsoTx;
-        if (rxAlsoTx) Tx = Rx;
-        return;
-      }
-
-      if (rxEngineIncludesTx != rxAlsoTx)
-        ReconfigureRxEngine(rxAlsoTx, crossband);
-    }
-
-    private void SyncTxEngine(bool wantTx, bool wantShare, bool crossband)
-    {
-      if (!wantTx)
-      {
-        if (Tx != null) RemoveTxEngine();
-        return;
-      }
-
-      if (wantShare)
-      {
-        if (Rx == null)
-        {
-          if (Tx != null) RemoveTxEngine();
-          return;
-        }
-
-        if (Tx != null && Tx != Rx)
-          RemoveTxEngine();
-
-        Tx = Rx;
-        return;
-      }
-
-      if (Tx == Rx)
-        Tx = null;
-
-      if (Tx != null) return;
-
-      Tx = CreateTxEngine();
-      Tx.Start(false, true, crossband);
-    }
-
-    private void ReconfigureRxEngine(bool rxAlsoTx, bool crossband)
-    {
-      RemoveRxEngine();
-      Rx = CreateRxEngine();
-      Rx.Start(true, rxAlsoTx, crossband);
-      rxEngineIncludesTx = rxAlsoTx;
-      if (rxAlsoTx) Tx = Rx;
-    }
-
-    private void RemoveRxEngine()
-    {
-      if (Rx == null) return;
-      if (Tx == Rx) Tx = null;
-      Rx.Dispose();
-      Rx = null;
-      rxEngineIncludesTx = false;
-    }
-
-    private void RemoveTxEngine()
-    {
-      if (Tx == null) return;
-      if (Tx != Rx)
-      {
-        Tx.Dispose();
-        Tx = null;
-      }
-      else
-        Tx = null;
-    }
-
-    private void DestroyAllEngines()
-    {
-      if (Tx != null && Tx != Rx) Tx.Dispose();
-      if (Tx == Rx) Tx = null;
-      Rx?.Dispose();
-      Rx = null;
-      Tx = null;
-      rxEngineIncludesTx = false;
-    }
-
-    private CatControlEngine CreateRxEngine()
-    {
-      var engine = new CatControlEngine(ctx.Settings.Cat.RxCat, ctx.Settings.Cat);
-      engine.RxTuned += (s, e) => ctx.FrequencyControl.RxTuned();
-      engine.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
-      return engine;
-    }
-
-    private CatControlEngine CreateTxEngine()
-    {
-      var engine = new CatControlEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat);
-      engine.TxTuned += (s, e) => ctx.FrequencyControl.TxTuned();
-      engine.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
-      return engine;
-    }
-
-    private static bool IsSameEngine(CatRadioSettings txCat, CatRadioSettings rxCat)
-    {
-      return rxCat.Enabled
-        && txCat.Enabled
-        && IsSameHostPort(rxCat, txCat);
-        //&& rxCat.RadioType == txCat.RadioType;
-    }
-
-    public static bool IsSameHostPort(CatRadioSettings txCat, CatRadioSettings rxCat)
-    {
-      if (rxCat.Port != txCat.Port) return false;
-      if (string.IsNullOrEmpty(rxCat.Host) || string.IsNullOrEmpty(txCat.Host))
-        return false;
-
-      string host1 = rxCat.Host;
-      string host2 = txCat.Host;
-
-      if (host1 == "127.0.0.1") host1 = "localhost";
-      if (host2 == "127.0.0.1") host2 = "localhost";
-
-      return string.Equals(host1, host2, StringComparison.OrdinalIgnoreCase);
-    }
-  }
-}
-
+﻿namespace SkyRoof
+{
+  public class CatControl
+  {
+    public Context ctx;
+    public CatControlEngine? Rx, Tx;
+    private bool rxEngineIncludesTx;
+    private bool rxEngineCrossband;
+
+    /// <summary>
+    /// Ensures CAT engines match settings and link topology. Does not restart engines
+    /// when only frequency/mode changed — <see cref="FrequencyWidget"/> pushes those via
+    /// SetRxFrequency / SetRxMode / SetTxFrequency on the live engines.
+    /// </summary>
+    internal void ApplyTune()
+    {
+      var link = ctx.FrequencyControl.RadioLink;
+      bool crossband = link.IsCrossBand;
+      bool wantRx = ctx.Settings.Cat.RxCat.Enabled;
+      bool wantTx = ctx.Settings.Cat.TxCat.Enabled && link.HasUplink;
+      bool wantShare = wantTx && wantRx && IsSameEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat.RxCat);
+      bool rxAlsoTx = wantTx && wantShare;
+
+      SyncRxEngine(wantRx, rxAlsoTx, crossband);
+      SyncTxEngine(wantTx, wantShare, crossband);
+
+      ctx.MainForm.ShowCatStatus();
+    }
+
+    internal void ApplySettings()
+    {
+      DestroyAllEngines();
+      ApplyTune();
+    }
+
+    private void SyncRxEngine(bool wantRx, bool rxAlsoTx, bool crossband)
+    {
+      if (!wantRx)
+      {
+        if (Rx != null) RemoveRxEngine();
+        return;
+      }
+
+      if (Rx == null)
+      {
+        Rx = CreateRxEngine();
+        Rx.Start(true, rxAlsoTx, crossband);
+        rxEngineIncludesTx = rxAlsoTx;
+        rxEngineCrossband = crossband;
+        if (rxAlsoTx) Tx = Rx;
+        return;
+      }
+
+      if (RxEngineConfigNeedsUpdate(rxAlsoTx, crossband))
+        ReconfigureRxEngine(rxAlsoTx, crossband);
+    }
+
+    private bool RxEngineConfigNeedsUpdate(bool rxAlsoTx, bool crossband) =>
+      rxEngineIncludesTx != rxAlsoTx || rxEngineCrossband != crossband;
+
+    private void SyncTxEngine(bool wantTx, bool wantShare, bool crossband)
+    {
+      if (!wantTx)
+      {
+        if (Tx != null) RemoveTxEngine();
+        return;
+      }
+
+      if (wantShare)
+      {
+        if (Rx == null)
+        {
+          if (Tx != null) RemoveTxEngine();
+          return;
+        }
+
+        if (Tx != null && Tx != Rx)
+          RemoveTxEngine();
+
+        Tx = Rx;
+        return;
+      }
+
+      if (Tx == Rx)
+        Tx = null;
+
+      if (Tx != null) return;
+
+      Tx = CreateTxEngine();
+      Tx.Start(false, true, crossband);
+    }
+
+    private void ReconfigureRxEngine(bool rxAlsoTx, bool crossband)
+    {
+      // Merging TX into the shared RX engine: dispose a standalone TX engine first so
+      // RemoveRxEngine + Tx = Rx does not leak the old TX thread/CAT connection.
+      if (rxAlsoTx && Tx != null && Tx != Rx)
+        RemoveTxEngine();
+
+      RemoveRxEngine();
+      Rx = CreateRxEngine();
+      Rx.Start(true, rxAlsoTx, crossband);
+      rxEngineIncludesTx = rxAlsoTx;
+      rxEngineCrossband = crossband;
+      if (rxAlsoTx) Tx = Rx;
+    }
+
+    private void RemoveRxEngine()
+    {
+      if (Rx == null) return;
+      if (Tx == Rx) Tx = null;
+      Rx.Dispose();
+      Rx = null;
+      rxEngineIncludesTx = false;
+      rxEngineCrossband = false;
+    }
+
+    private void RemoveTxEngine()
+    {
+      if (Tx == null) return;
+      if (Tx != Rx)
+      {
+        Tx.Dispose();
+        Tx = null;
+      }
+      else
+        Tx = null;
+    }
+
+    private void DestroyAllEngines()
+    {
+      if (Tx != null && Tx != Rx) Tx.Dispose();
+      if (Tx == Rx) Tx = null;
+      Rx?.Dispose();
+      Rx = null;
+      Tx = null;
+      rxEngineIncludesTx = false;
+      rxEngineCrossband = false;
+    }
+
+    private CatControlEngine CreateRxEngine()
+    {
+      var engine = new CatControlEngine(ctx.Settings.Cat.RxCat, ctx.Settings.Cat);
+      engine.RxTuned += (s, e) => ctx.FrequencyControl.RxTuned();
+      engine.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
+      return engine;
+    }
+
+    private CatControlEngine CreateTxEngine()
+    {
+      var engine = new CatControlEngine(ctx.Settings.Cat.TxCat, ctx.Settings.Cat);
+      engine.TxTuned += (s, e) => ctx.FrequencyControl.TxTuned();
+      engine.StatusChanged += (s, e) => ctx.MainForm.ShowCatStatus();
+      return engine;
+    }
+
+    private static bool IsSameEngine(CatRadioSettings txCat, CatRadioSettings rxCat)
+    {
+      return rxCat.Enabled
+        && txCat.Enabled
+        && IsSameHostPort(rxCat, txCat);
+        //&& rxCat.RadioType == txCat.RadioType;
+    }
+
+    public static bool IsSameHostPort(CatRadioSettings txCat, CatRadioSettings rxCat)
+    {
+      if (rxCat.Port != txCat.Port) return false;
+      if (string.IsNullOrEmpty(rxCat.Host) || string.IsNullOrEmpty(txCat.Host))
+        return false;
+
+      string host1 = rxCat.Host;
+      string host2 = txCat.Host;
+
+      if (host1 == "127.0.0.1") host1 = "localhost";
+      if (host2 == "127.0.0.1") host2 = "localhost";
+
+      return string.Equals(host1, host2, StringComparison.OrdinalIgnoreCase);
+    }
+  }
+}
+

--- a/SkyRoof/Widgets/FrequencyWidget.cs
+++ b/SkyRoof/Widgets/FrequencyWidget.cs
@@ -57,7 +57,7 @@ namespace SkyRoof
     {
       SettingsToRadioLink(false);
       RadioLinkToUi();
-      ctx.CatControl.ApplySettings();
+      ctx.CatControl.ApplyTune();
       ctx.RotatorControl.SetSatellite(ctx.SatelliteSelector.SelectedSatellite);
       RadioLinkToRadio();
       UpdateTxButton();
@@ -67,7 +67,7 @@ namespace SkyRoof
     {
       SettingsToRadioLink(true, frequency);
       RadioLinkToUi();
-      ctx.CatControl.ApplySettings();
+      ctx.CatControl.ApplyTune();
       ctx.RotatorControl.SetSatellite(null);
       RadioLinkToRadio();
       UpdateTxButton();


### PR DESCRIPTION
The code that changes frequencies when clicking transmitters, waterfall etc was tearing down and recreating the CAT connection for both RX and TX which causes a large delay where the entire UI locks up for ~a half second. Unless there was a reason it was getting recreated every time that I don't know about, this fix changes it to use the existing connection and just change the frequency.